### PR TITLE
fix creation of new folders

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -31,7 +31,7 @@ pkgver() {
 }
 
 prepare() {
-	mkdir "${_pkgname}/dist"
+	mkdir -p "${_pkgname}/dist"
 }
 
 build() {


### PR DESCRIPTION
Fix a problem, when create a `dist` directory when parent folder `ChatGPT` does not exist. It's pre-build step.