### PR TITLE
Fix File Exists error in prepare()

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -34,7 +34,9 @@ pkgver() {
 prepare() {
 	# Set CARGO_HOME to "${srcdir}/cargo"
 	export CARGO_HOME="${srcdir}/cargo"
-	mkdir "${_pkgname}/dist"
+	if [ ! -d "${_pkgname}/dist" ]; then 
+		mkdir "${_pkgname}/dist"
+	fi
 	
 	# Download Rust dependencies
 	cd "${_pkgname}"


### PR DESCRIPTION
Error occurs when installing in prepare(). "mkdir: cannot create directory ‘ChatGPT/dist’: File exists.
mkdir: cannot create directory ‘ChatGPT/dist’: File exists". Solution to check if the folder exists before blindly calling mkdir _pkgname/dist.

![2023-02-18-130959_933x346_scrot](https://user-images.githubusercontent.com/621477/219867622-13ed3785-88d1-4dea-999c-9ed0fd99269e.png)
